### PR TITLE
Test enhancement

### DIFF
--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -2,4 +2,4 @@
 
 error_reporting(E_ALL | E_STRICT);
 
-require_once dirname(__FILE__).'/../vendor/autoload.php';
+require_once __DIR__.'/../vendor/autoload.php';

--- a/test/helpers/ComponentMockeryTrait.php
+++ b/test/helpers/ComponentMockeryTrait.php
@@ -112,7 +112,7 @@ PHP;
      *
      * @throws Exception If problem creating.
      */
-    protected function createCallable(callable $callable): callable
+    protected function createCallable(callable $callable)
     {
         static $className = null;
 
@@ -167,8 +167,6 @@ EOL;
                         $mock,
                         $key
                     );
-
-                    throw $e;
                 }
 
                 return $services[$key];
@@ -176,11 +174,7 @@ EOL;
 
         $mock->method('has')
             ->willReturnCallback(function ($key) use ($services, $mock) {
-                if (!isset($services[$key])) {
-                    return false;
-                }
-
-                return true;
+                return isset($services[$key]);
             });
 
         return $mock;


### PR DESCRIPTION
# Changed log
- Using the `__DIR__` to load current path of `vendor/autoload.php` without using the `dirname` function call and `__FILE__` const.
- Remove the `throw $e` syntax because it's unused.
- To keep the condition easily, just use `return isset($services[$key]);` to return the boolean value directly.