### PR TITLE
Add FlashContainer

### DIFF
--- a/src/FlashContainer.php
+++ b/src/FlashContainer.php
@@ -118,6 +118,7 @@ class FlashContainer implements
     public function clear(): void
     {
         $this->flashData = [];
+        $this->persist();
     }
 
     /**

--- a/src/FlashContainer.php
+++ b/src/FlashContainer.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Dhii\Container;
+
+use Dhii\Collection\ClearableContainerInterface;
+use Dhii\Collection\MutableContainerInterface;
+use Dhii\Container\Exception\NotFoundException;
+use Psr\Container\ContainerExceptionInterface;
+
+/**
+ * A container for data that is accessible once per init.
+ *
+ * The {@see init()} method copies data from the internal container into memory,
+ * then clears it. The data is still accessible from memory,
+ * but no longer from internal container.
+ *
+ * This is useful for flash data, i.e. data that should only be accessible
+ * once per request. If a session-specific persistent container is used
+ * as storage, this will become session-based flash data.
+ */
+class FlashContainer implements
+    MutableContainerInterface,
+    ClearableContainerInterface
+{
+    /** @var MutableContainerInterface */
+    protected $data;
+    /** @var string */
+    protected $dataKey;
+    /** @var array */
+    protected $flashData = [];
+
+    /**
+     * @param MutableContainerInterface $data The storage.
+     * @param string $dataKey The key to be used to store data in the storage.
+     */
+    public function __construct(MutableContainerInterface $data, string $dataKey)
+    {
+        $this->data = $data;
+        $this->dataKey = $dataKey;
+    }
+
+    /**
+     * Prepare storage before use.
+     *
+     * Should be called once before accessing data through this class.
+     * Will clear the data for the configured key from the storage.
+     */
+    public function init(): void
+    {
+        $this->flashData = $this->data->has($this->dataKey)
+            ? $this->data->get($this->dataKey)
+            : [];
+
+        $this->purgePersistentData();
+    }
+
+    /**
+     * Clear data from internal storage.
+     */
+    protected function purgePersistentData(): void
+    {
+        $this->data->set($this->dataKey, []);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->flashData);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Retrieves the value for the specified key from memory.
+     */
+    public function get($key)
+    {
+        if (!array_key_exists($key, $this->flashData)) {
+            throw new NotFoundException(sprintf('Flash data not found for key "%1$s"', $key));
+        }
+
+        return $this->flashData[$key];
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Assigns the given value to the specified key in memory, and persists this change in storage.
+     */
+    public function set(string $key, $value): void
+    {
+        $this->flashData[$key] = $value;
+        $this->persist();
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Removes the specified key from memory, and persists this change in storage.
+     */
+    public function unset(string $key): void
+    {
+        if (!array_key_exists($key, $this->flashData)) {
+            throw new NotFoundException(sprintf('Flash data not found for key "%1$s"', $key));
+        }
+
+        unset($this->flashData[$key]);
+        $this->persist();
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Clears all of this instance's data from memory.
+     */
+    public function clear(): void
+    {
+        $this->flashData = [];
+    }
+
+    /**
+     * Persist this instance's data from memory into storage.
+     */
+    protected function persist(): void
+    {
+        $this->data->set($this->dataKey, $this->flashData);
+    }
+}

--- a/src/FlashContainer.php
+++ b/src/FlashContainer.php
@@ -92,7 +92,7 @@ class FlashContainer implements
     public function set(string $key, $value): void
     {
         $this->flashData[$key] = $value;
-        $this->persist();
+        $this->persist($this->flashData);
     }
 
     /**
@@ -107,7 +107,7 @@ class FlashContainer implements
         }
 
         unset($this->flashData[$key]);
-        $this->persist();
+        $this->persist($this->flashData);
     }
 
     /**
@@ -118,14 +118,16 @@ class FlashContainer implements
     public function clear(): void
     {
         $this->flashData = [];
-        $this->persist();
+        $this->persist($this->flashData);
     }
 
     /**
      * Persist this instance's data from memory into storage.
+     *
+     * @param array $data The data to persist.
      */
-    protected function persist(): void
+    protected function persist(array $data): void
     {
-        $this->data->set($this->dataKey, $this->flashData);
+        $this->data->set($this->dataKey, $data);
     }
 }

--- a/test/functional/FlashContainerTest.php
+++ b/test/functional/FlashContainerTest.php
@@ -113,6 +113,7 @@ class FlashContainerTest extends TestCase
             // Clearing
             $subject->clear();
             $this->assertFalse($subject->has($key2), 'Flash data was not cleared correctly');
+            $this->assertEquals([], $storage->get($storageKey), 'Flash data clearing not persisted correctly');
 
             // Isolation
             $this->assertEquals($otherStorageValue, $storage->get($otherStorageKey), 'Other storage values affected by flash data');

--- a/test/functional/FlashContainerTest.php
+++ b/test/functional/FlashContainerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Dhii\Container\FuncTest;
+
+use Dhii\Collection\MutableContainerInterface;
+use Dhii\Container\FlashContainer as Subject;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FlashContainerTest extends TestCase
+{
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @param MutableContainerInterface $storage
+     * @param string                    $key
+     *
+     * @return MockObject&Subject The new instance.
+     */
+    protected function createSubject(MutableContainerInterface $storage, string $key)
+    {
+        $mock = $this->getMockBuilder(Subject::class)
+            ->enableProxyingToOriginalMethods()
+            ->enableOriginalConstructor()
+            ->setConstructorArgs([$storage, $key])
+            ->getMock();
+
+        return $mock;
+    }
+
+    /**
+     * @return MockObject&MutableContainerInterface
+     */
+    protected function createStorage(array $data): MutableContainerInterface
+    {
+        $mock = $this->getMockBuilder(MutableContainerInterface::class)
+            ->setMethods(['has', 'get', 'set', 'unset'])
+            ->getMockForAbstractClass();
+
+        $mock->data = $data;
+
+        $mock->method('has')
+            ->with($this->isType('string'))
+            ->will($this->returnCallback(function (string $key) use ($mock) {
+                return array_key_exists($key, $mock->data);
+            }));
+        $mock->method('get')
+            ->with($this->isType('string'))
+            ->will($this->returnCallback(function (string $key) use ($mock) {
+                return array_key_exists($key, $mock->data)
+                    ? $mock->data[$key]
+                    : null;
+            }));
+        $mock->method('set')
+            ->with($this->isType('string'), $this->anything())
+            ->will($this->returnCallback(function (string $key, $value) use ($mock) {
+                $mock->data[$key] = $value;
+            }));
+        $mock->method('unset')
+            ->with($this->isType('string'))
+            ->will($this->returnCallback(function (string $key) use ($mock) {
+                if (array_key_exists($key, $mock->data)) {
+                    unset($mock->data[$key]);
+                }
+            }));
+
+        return $mock;
+    }
+
+    /**
+     * Tests that flash data operations work correctly, and only affect the designated key of the storage.
+     *
+     * @return Subject
+     */
+    public function testCrud(): Subject
+    {
+        {
+            $key1 = uniqid('key1');
+            $val1 = uniqid('val1');
+            $key2 = uniqid('key2');
+            $val2 = uniqid('val2');
+            $initialFlashData = [$key1 => $val1];
+            $otherStorageKey = uniqid('other-storage-key');
+            $otherStorageValue = uniqid('other-storage-value');
+            $storageKey = uniqid('storage-key');
+            $storage = $this->createStorage([
+                $storageKey => $initialFlashData,
+                $otherStorageKey => $otherStorageValue,
+            ]);
+            $subject = $this->createSubject($storage, $storageKey);
+        }
+
+        {
+            // Initialization
+            $this->assertEquals($initialFlashData, $storage->get($storageKey), 'Initial flash data not set in storage');
+            $this->assertFalse($subject->has($key1), 'Flash data available before initialization');
+            $subject->init();
+            $this->assertEquals([], $storage->get($storageKey), 'Flash data not cleared from storage');
+
+            // Retrieval
+            $this->assertEquals($val1, $subject->get($key1));
+
+            // Writing
+            $subject->set($key2, $val2);
+            $this->assertEquals($val2, $subject->get($key2), 'Flash value not set correctly');
+            $this->assertEquals(array_merge($initialFlashData, [$key2 => $val2]), $storage->get($storageKey), 'Flash value not persisted correctly');
+
+            // Deleting
+            $subject->unset($key1);
+            $this->assertFalse($subject->has($key1), 'Flash value not unset correctly');
+            $this->assertEquals([$key2 => $val2], $storage->get($storageKey), 'Flash value removal not persisted correctly');
+
+            // Clearing
+            $subject->clear();
+            $this->assertFalse($subject->has($key2), 'Flash data was not cleared correctly');
+
+            // Isolation
+            $this->assertEquals($otherStorageValue, $storage->get($otherStorageKey), 'Other storage values affected by flash data');
+        }
+
+        return $subject;
+    }
+}


### PR DESCRIPTION
Adds a container for flashdata. This uses an inner container for storage, and wipes its designated key's data from it on initialization, transferring data from storage into memory. Can be used, for example, with a session container to implement user session-based flashdata.