### PR TITLE
Fix namespace to be compatible PSR-4 autoloading

### DIFF
--- a/test/functional/Dhii/Container/FuncTest/CachingContainerTest.php
+++ b/test/functional/Dhii/Container/FuncTest/CachingContainerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Container\FuncTest;
+namespace Dhii\Container\FuncTest\Dhii\Container\FuncTest;
 
 use Dhii\Container\CachingContainer as TestSubject;
 use Dhii\Container\TestHelpers\ComponentMockeryTrait;

--- a/test/functional/Dhii/Container/FuncTest/CompositeContainerTest.php
+++ b/test/functional/Dhii/Container/FuncTest/CompositeContainerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dhii\Container\FuncTest;
+namespace Dhii\Container\FuncTest\Dhii\Container\FuncTest;
 
 use Dhii\Container\CompositeContainer;
 use Dhii\Container\TestHelpers\ContainerMock;


### PR DESCRIPTION
It should let the `test/functional/Dhii/Container/FuncTest/CachingContainerTest.php` and `test/functional/Dhii/Container/FuncTest/CompositeContainerTest.php` class namespaces change into `Dhii\Container\FuncTest\Dhii\Container\FuncTest` because it can be compatible with `PSR-4` autloader.

And these above files are under the `test/functional/Dhii/Container/FuncTest/` folder.