### PR TITLE
Add iteration capability to `SegmentingContainer`

### DIFF
--- a/src/SegmentingContainer.php
+++ b/src/SegmentingContainer.php
@@ -9,9 +9,7 @@ use Exception;
 use Iterator;
 use IteratorAggregate;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
-
 use Traversable;
-
 use UnexpectedValueException;
 
 use function array_filter;
@@ -134,7 +132,7 @@ class SegmentingContainer implements ContainerInterface, Iterator
         return $this->iterator->current();
     }
 
-    public function next()
+    public function next(): void
     {
         $this->iterator->next();
     }
@@ -149,7 +147,7 @@ class SegmentingContainer implements ContainerInterface, Iterator
         return $this->startsWith($this->iterator->key(), $this->root);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         if (!($this->inner instanceof Traversable)) {
             throw new UnexpectedValueException('Cannot rewind: inner container not an iterator');

--- a/tests/system/MultipleAccessTypesWithMapsTest.php
+++ b/tests/system/MultipleAccessTypesWithMapsTest.php
@@ -8,7 +8,7 @@ use Dhii\Container\DictionaryFactory;
 use Dhii\Container\SegmentingContainer;
 use PHPUnit\Framework\TestCase;
 
-class MultipleAccessTypesWithMaps__ extends TestCase
+class MultipleAccessTypesWithMaps extends TestCase
 {
     const DEV_DB_HOST = 'localhost';
     const STAGING_DB_HOST = '123.staging.myhost';
@@ -85,8 +85,6 @@ class MultipleAccessTypesWithMaps__ extends TestCase
         }
 
         {
-            $this->markTestIncomplete('This will fail, because the segmenting container is not iterable, ' .
-                                      'and will return instances of itself for keys that are not found.');
             $this->assertIsIterable($container->get('staging')->get('db'));
         }
     }


### PR DESCRIPTION
This is an experimental attempt to make `SegmentingContainer` iterable.

## Problems
The main problem that this presents can be described in the following way:

1. If a `ContainerInterface` is given, how can a decorator iterate over its members? Spoiler: it cannot.
2. If additional support is provided in case that `ContainerInterface` is also `Traversable` (such as `MapInterface`), how does one switch determine what the next element is, since the inner container will enumerate _all_ members and not only those that begin with the root key?
	- Can refuse iteration (expose no further elements) if the next inner key does not match the root key (this is the approach taken here).
	- Can also continue scanning elements until one matching the root key is found. But this may require many iterations, and is therefore not performant: it may need to scan thousands of elements before the next valid key is found, or even scan them for nothing if there are still elements but no further valid keys. Also, this will hang with an infinite iterator.
3. If the root is `Traversable`, how does one indicate that for the return value of `get()` in a type-safe way? `SegmentingIterator#get()` returns copies of itself. And itself is either traversable or not, which means that _all_ retrieved segments are either traversable or not. For proper typing, some would need to be traversable, and some not - depending on whether the inner container has multiple items that start with the root key.

## More Problems
This also opens questions like these:

1. How does one separate the capabilities of key retrieval and of iteration, such that the latter can extend the former?
2. In general, how does one extend functionality of a type in a maintainable way, if the type it is extending limits information about the value it wraps - information that is critical to the extension?

	*Example*. A `SegmentingContainer` allows reading information by a specific key only. A `SegmentingMap` (an iterable segmenting container) would need to iterate over the data in the `SegmentingContainer`. But it canot do that, because it is agnostic of the actual data storage, and the container it wraps does not enumerate its members - in fact, they may not be enumerable at all.

Inheritance and compile-time composition are also available options. However, this would reduce maintainability, and add complexity.