### PR TITLE
Revert "Upgrade to Container Interop v2"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,7 @@
 name: Continuous Integration
 
 on:
-  pull_request:
-    branches:
-      - '*.*.*'
-      - 'master'
   push:
-    branches:
-      - '*.*.*'
-      - 'master'
   workflow_dispatch:
 
 jobs:

--- a/.idea/containers.iml
+++ b/.idea/containers.iml
@@ -2,7 +2,9 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/tests/functional" isTestSource="true" packagePrefix="Dhii\Container\FuncTest\" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/tests/unit" isTestSource="true" packagePrefix="Dhii\Container\UnitTest\" />
       <sourceFolder url="file://$MODULE_DIR$/tests/system" isTestSource="true" packagePrefix="Dhii\Container\SysTest\" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Dhii\Container\" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Recursion detection (#13).
 
-### Changed
-- Dropped support for `psr/container` v1 in favour of v2 (#29).
-- Switched underlying Dhii standards (#29).
-
 ## [0.1.5] - 2024-04-27
 ### Fixed
 - Missing return types causing warnings with PHP 8.1 and higher (#25).

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "prefer-stable": false,
     "require": {
         "php": "^7.4 | ^8.0",
-        "dhii/collections-interface": "^0.4.0-alpha2",
+        "dhii/collections-interface": "^0.3.0-alpha4",
         "container-interop/service-provider": "^0.4"
     },
     "require-dev": {
@@ -25,7 +25,7 @@
         "phpunit/phpunit": "^9.0",
         "vimeo/psalm": "^5.0",
         "gmazzap/andrew": "^1.1",
-        "psr/container": "^2.0",
+        "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",
         "wildwolf/psr-memory-cache": "^1.0"
     },
@@ -40,6 +40,11 @@
             "Dhii\\Container\\FuncTest\\": "tests/functional",
             "Dhii\\Container\\SysTest\\": "tests/system",
             "Dhii\\Container\\TestHelpers\\": "tests/helpers"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "0.1.x-dev"
         }
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a0a03723e92b74d821d53755e41aa82",
+    "content-hash": "a39fbdfee637c101d92a17cd7bdec485",
     "packages": [
         {
             "name": "container-interop/service-provider",
@@ -43,29 +43,34 @@
         },
         {
             "name": "dhii/collections-interface",
-            "version": "0.4.x-dev",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/collections-interface.git",
-                "reference": "f860c73a3f22b952663ccae7941d36bdd3b4b504"
+                "reference": "74464a969b340d16889eacd9eadc9817f7e7f47a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/collections-interface/zipball/f860c73a3f22b952663ccae7941d36bdd3b4b504",
-                "reference": "f860c73a3f22b952663ccae7941d36bdd3b4b504",
+                "url": "https://api.github.com/repos/Dhii/collections-interface/zipball/74464a969b340d16889eacd9eadc9817f7e7f47a",
+                "reference": "74464a969b340d16889eacd9eadc9817f7e7f47a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 | ^8.0",
-                "psr/container": "^1.0 | ^2.0"
+                "php": "^7.1 | ^8.0",
+                "psr/container": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0",
+                "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
                 "slevomat/coding-standard": "^6.0",
-                "vimeo/psalm": "^4.6.2 | ^5.0"
+                "vimeo/psalm": "^4.0"
             },
             "default-branch": true,
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.3.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Dhii\\Collection\\": "src"
@@ -88,34 +93,28 @@
             "description": "A highly ISP-compliant collection of interfaces that represent maps and lists.",
             "support": {
                 "issues": "https://github.com/Dhii/collections-interface/issues",
-                "source": "https://github.com/Dhii/collections-interface/tree/0.4.x"
+                "source": "https://github.com/Dhii/collections-interface/tree/v0.3.0"
             },
-            "time": "2024-09-21T21:40:54+00:00"
+            "time": "2021-10-06T10:56:09+00:00"
         },
         {
             "name": "psr/container",
-            "version": "dev-master",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "707984727bd5b2b670e59559d3ed2500240cf875"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/707984727bd5b2b670e59559d3ed2500240cf875",
-                "reference": "707984727bd5b2b670e59559d3ed2500240cf875",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
-            "default-branch": true,
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -142,9 +141,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2023-09-22T11:11:30+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         }
     ],
     "packages-dev": [
@@ -3898,29 +3897,37 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.2",
+            "version": "2.5.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
+                "reference": "351fb560172c6972ffa169f4ffaea6d58a9de33b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
-                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/351fb560172c6972ffa169f4ffaea6d58a9de33b",
+                "reference": "351fb560172c6972ffa169f4ffaea6d58a9de33b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
-                "psr/container": "",
                 "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -3953,9 +3960,23 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v1.1.2"
+                "source": "https://github.com/symfony/service-contracts/tree/2.5"
             },
-            "time": "2019-05-28T07:50:59+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/string",

--- a/src/AliasingContainer.php
+++ b/src/AliasingContainer.php
@@ -49,17 +49,23 @@ class AliasingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         return $this->inner->get($this->getInnerKey($key));
     }
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         return $this->inner->has($this->getInnerKey($key));
     }
 

--- a/src/CachingContainer.php
+++ b/src/CachingContainer.php
@@ -39,8 +39,14 @@ class CachingContainer implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function get(string $key)
+    public function get($key)
     {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * @psalm-suppress RedundantCast
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
         /**
          * @psalm-suppress InvalidCatch
          * The base interface does not extend Throwable, but in fact everything that is possible
@@ -70,8 +76,13 @@ class CachingContainer implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
         /**
          * @psalm-suppress InvalidCatch
          * The base interface does not extend Throwable, but in fact everything that is possible

--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -11,6 +11,8 @@ use Dhii\Container\Util\StringTranslatingTrait;
 use Exception;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Traversable;
+use UnexpectedValueException;
 
 class CompositeContainer implements ContainerInterface
 {
@@ -32,8 +34,14 @@ class CompositeContainer implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function get(string $key)
+    public function get($key)
     {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * @psalm-suppress RedundantCast
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
         foreach ($this->containers as $index => $container) {
             /**
              * @psalm-suppress InvalidCatch
@@ -69,8 +77,13 @@ class CompositeContainer implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
         foreach ($this->containers as $index => $container) {
             try {
                 if ($container->has($key)) {

--- a/src/DataStructureBasedFactory.php
+++ b/src/DataStructureBasedFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Dhii\Container;
 
 use Dhii\Collection\WritableMapFactoryInterface;
-use Dhii\Collection\WritableMapInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @inheritDoc
@@ -24,7 +24,7 @@ class DataStructureBasedFactory implements DataStructureBasedFactoryInterface
     /**
      * @inheritDoc
      */
-    public function createContainerFromArray(array $structure): WritableMapInterface
+    public function createContainerFromArray(array $structure): ContainerInterface
     {
         $map = [];
         foreach ($structure as $key => $value) {

--- a/src/DataStructureBasedFactoryInterface.php
+++ b/src/DataStructureBasedFactoryInterface.php
@@ -7,6 +7,7 @@ namespace Dhii\Container;
 use Dhii\Collection\WritableMapFactoryInterface;
 use Dhii\Collection\WritableMapInterface;
 use Exception;
+use Psr\Container\ContainerInterface as BaseContainerInterface;
 
 /**
  * Creates a container hierarchy based on a traditional data structure.
@@ -22,5 +23,5 @@ interface DataStructureBasedFactoryInterface extends WritableMapFactoryInterface
      *
      * @throws Exception If problem creating.
      */
-    public function createContainerFromArray(array $structure): WritableMapInterface;
+    public function createContainerFromArray(array $structure): BaseContainerInterface;
 }

--- a/src/DelegatingContainer.php
+++ b/src/DelegatingContainer.php
@@ -43,7 +43,7 @@ class DelegatingContainer implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function get(string $id)
+    public function get($id)
     {
         if (array_key_exists($id, $this->stack)) {
             $trace = implode(' -> ', array_keys($this->stack)) . ' -> ' . $id;
@@ -67,9 +67,10 @@ class DelegatingContainer implements ContainerInterface
     /**
      * {@inheritDoc}
      */
-    public function has(string $id): bool
+    public function has($id)
     {
         $services = $this->provider->getFactories();
+        $id = (string) $id;
 
         return array_key_exists($id, $services);
     }

--- a/src/DeprefixingContainer.php
+++ b/src/DeprefixingContainer.php
@@ -56,8 +56,10 @@ class DeprefixingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         /**
          * @psalm-suppress InvalidCatch
@@ -77,9 +79,12 @@ class DeprefixingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
         $realKey = $this->getInnerKey($key);
 
         return $this->inner->has($realKey) || (!$this->strict && $this->inner->has($key));
@@ -87,6 +92,8 @@ class DeprefixingContainer implements ContainerInterface
 
     /**
      * Retrieves the key to use for the inner container.
+     *
+     * @since [*next-version*]
      *
      * @param string $key The outer key.
      *

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -36,7 +36,7 @@ class Dictionary implements
     /**
      * {@inheritDoc}
      */
-    public function get(string $key)
+    public function get($key)
     {
         if (!array_key_exists($key, $this->data)) {
             throw new NotFoundException(
@@ -52,8 +52,10 @@ class Dictionary implements
     /**
      * {@inheritDoc}
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         $isHas = array_key_exists($key, $this->data);
 
         return $isHas;

--- a/src/DictionaryFactory.php
+++ b/src/DictionaryFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Dhii\Container;
 
 use Dhii\Collection\WritableMapFactoryInterface;
-use Dhii\Collection\WritableMapInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @inheritDoc
@@ -15,7 +15,7 @@ class DictionaryFactory implements WritableMapFactoryInterface
     /**
      * @inheritDoc
      */
-    public function createContainerFromArray(array $data): WritableMapInterface
+    public function createContainerFromArray(array $data): ContainerInterface
     {
         return new Dictionary($data);
     }

--- a/src/FlashContainer.php
+++ b/src/FlashContainer.php
@@ -7,6 +7,7 @@ namespace Dhii\Container;
 use Dhii\Collection\ClearableContainerInterface;
 use Dhii\Collection\MutableContainerInterface;
 use Dhii\Container\Exception\NotFoundException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * A container for data that is accessible once per init.
@@ -58,8 +59,10 @@ class FlashContainer implements
     /**
      * @inheritDoc
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         return array_key_exists($key, $this->flashData);
     }
 
@@ -68,7 +71,7 @@ class FlashContainer implements
      *
      * Retrieves the value for the specified key from memory.
      */
-    public function get(string $key)
+    public function get($key)
     {
         if (!array_key_exists($key, $this->flashData)) {
             throw new NotFoundException(sprintf('Flash data not found for key "%1$s"', $key));

--- a/src/HierarchyContainer.php
+++ b/src/HierarchyContainer.php
@@ -59,8 +59,10 @@ class HierarchyContainer implements ContainerInterface
 
     /**
      * @inheritDoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         if (!array_key_exists($key, $this->data)) {
             throw new NotFoundException("Key '{$key}' does not exist", 0, null);
@@ -81,9 +83,13 @@ class HierarchyContainer implements ContainerInterface
 
     /**
      * @inheritDoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         return array_key_exists($key, $this->data);
     }
 }

--- a/src/MappingContainer.php
+++ b/src/MappingContainer.php
@@ -34,15 +34,28 @@ use Psr\Container\ContainerInterface as PsrContainerInterface;
  */
 class MappingContainer implements ContainerInterface
 {
+    /* @since [*next-version*] */
     use StringTranslatingTrait;
 
-    /** @var callable */
+    /**
+     * @since [*next-version*]
+     *
+     * @var callable
+     */
     protected $callback;
 
-    /** @var PsrContainerInterface */
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
     protected $inner;
 
     /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
      * @param PsrContainerInterface $inner    The container instance to decorate.
      * @param callable              $callback The callback to invoke on get. It will be passed 3 parameters:
      *                                         * The inner container's value for the key being fetched.
@@ -57,6 +70,8 @@ class MappingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
     public function get($key)
     {
@@ -65,9 +80,13 @@ class MappingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         return $this->inner->has($key);
     }
 }

--- a/src/MaskingContainer.php
+++ b/src/MaskingContainer.php
@@ -13,9 +13,12 @@ use function array_key_exists;
 
 /**
  * An implementation of a container that wraps around another to selectively expose or mask certain keys.
+ *
+ * @since [*next-version*]
  */
 class MaskingContainer implements ContainerInterface
 {
+    /* @since [*next-version*] */
     use StringTranslatingTrait;
 
     /**
@@ -36,6 +39,8 @@ class MaskingContainer implements ContainerInterface
     /**
      * Constructor.
      *
+     * @since [*next-version*]
+     *
      * @param PsrContainerInterface $inner       The container whose entries to mask.
      * @param bool                  $defaultMask The default mask. If true, all inner keys are exposed. If false, all
      *                                           inner keys are hidden. Any keys specified in the $mask parameter will
@@ -52,8 +57,10 @@ class MaskingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         if (!$this->isExposed($key)) {
             throw new NotFoundException(
@@ -68,14 +75,20 @@ class MaskingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         return $this->isExposed($key) && $this->inner->has($key);
     }
 
     /**
      * Checks if a key is exposed through the mask.
+     *
+     * @since [*next-version*]
      *
      * @param string $key The key to check.
      *

--- a/src/NoOpContainer.php
+++ b/src/NoOpContainer.php
@@ -29,7 +29,7 @@ class NoOpContainer implements
     /**
      * @inheritDoc
      */
-    public function get(string $id)
+    public function get($id)
     {
         throw new NotFoundException('NoOp container cannot have values');
     }
@@ -37,7 +37,7 @@ class NoOpContainer implements
     /**
      * @inheritDoc
      */
-    public function has(string $id): bool
+    public function has($id)
     {
         return false;
     }

--- a/src/PathContainer.php
+++ b/src/PathContainer.php
@@ -45,17 +45,30 @@ use Psr\Container\NotFoundExceptionInterface;
  * Note that this implementation DOES NOT create containers for hierarchical _values_. Each segment in a given path
  * must correspond to a child {@link ContainerInterface} instance.
  *
+ * @since [*next-version*]
  * @see   SegmentingContainer For an implementation that achieves the opposite effect.
  */
 class PathContainer implements ContainerInterface
 {
-    /** @var PsrContainerInterface */
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
     protected $inner;
 
-    /** @var non-empty-string */
+    /**
+     * @since [*next-version*]
+     *
+     * @var non-empty-string
+     */
     protected $delimiter;
 
     /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
      * @param PsrContainerInterface $inner     The container instance to decorate.
      * @param non-empty-string      $delimiter The path delimiter to use.
      */
@@ -67,8 +80,10 @@ class PathContainer implements ContainerInterface
 
     /**
      * @inheritDoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         $tKey = (strpos($key, $this->delimiter) === 0)
             ? substr($key, strlen($this->delimiter))
@@ -107,9 +122,13 @@ class PathContainer implements ContainerInterface
 
     /**
      * @inheritDoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         /**
          * @psalm-suppress InvalidCatch
          * The base interface does not extend Throwable, but in fact everything that is possible

--- a/src/PrefixingContainer.php
+++ b/src/PrefixingContainer.php
@@ -15,19 +15,37 @@ use RuntimeException;
 /**
  * A container implementation that wraps around an inner container and prefixes its keys, requiring consumers to
  * include them when fetching or looking up data.
+ *
+ * @since [*next-version*]
  */
 class PrefixingContainer implements ContainerInterface
 {
-    /** @var PsrContainerInterface */
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
     protected $inner;
 
-    /** @var string */
+    /**
+     * @since [*next-version*]
+     *
+     * @var string
+     */
     protected $prefix;
 
-    /** @var bool */
+    /**
+     * @since [*next-version*]
+     *
+     * @var bool
+     */
     protected $strict;
 
     /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
      * @param PsrContainerInterface $container The container whose keys to prefix.
      * @param string                $prefix    The prefix to apply to the container's keys.
      * @param bool                  $strict    Whether or not to fallback to un-prefixed keys if a prefixed key does not
@@ -42,8 +60,10 @@ class PrefixingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         if (!$this->isPrefixed($key) && $this->strict) {
             throw new NotFoundException(sprintf('Key "%s" does not exist', $key));
@@ -67,9 +87,12 @@ class PrefixingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
         if (!$this->isPrefixed($key) && $this->strict) {
             return false;
         }
@@ -86,6 +109,8 @@ class PrefixingContainer implements ContainerInterface
     /**
      * Retrieves the key to use for the inner container.
      *
+     * @since [*next-version*]
+     *
      * @param string $key The outer key.
      *
      * @return string The inner key.
@@ -99,6 +124,8 @@ class PrefixingContainer implements ContainerInterface
 
     /**
      * Checks if the key is prefixed.
+     *
+     * @since [*next-version*]
      *
      * @param string $key The key to check.
      *

--- a/src/ProxyContainer.php
+++ b/src/ProxyContainer.php
@@ -35,7 +35,7 @@ class ProxyContainer implements BaseContainerInterface
     /**
      * @inheritDoc
      */
-    public function get(string $key)
+    public function get($key)
     {
         if (!($this->innerContainer instanceof BaseContainerInterface)) {
             throw new ContainerException($this->__('Inner container not set'));
@@ -47,7 +47,7 @@ class ProxyContainer implements BaseContainerInterface
     /**
      * @inheritDoc
      */
-    public function has(string $key): bool
+    public function has($key)
     {
         if (!($this->innerContainer instanceof BaseContainerInterface)) {
             /** @psalm-suppress MissingThrowsDocblock The exception class implements declared thrown interface */

--- a/src/SegmentingContainer.php
+++ b/src/SegmentingContainer.php
@@ -50,6 +50,7 @@ use function ltrim;
  * $dbConfig->get("port"); // 3306
  * ```
  *
+ * @since [*next-version*]
  * @see   PathContainer For an implementation that achieves the opposite effect.
  */
 class SegmentingContainer implements ContainerInterface
@@ -86,8 +87,10 @@ class SegmentingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function get(string $key)
+    public function get($key)
     {
         $tKey = ltrim($key, $this->delimiter);
         $tRoot = rtrim($this->root, $this->delimiter);
@@ -106,9 +109,13 @@ class SegmentingContainer implements ContainerInterface
 
     /**
      * @inheritdoc
+     *
+     * @since [*next-version*]
      */
-    public function has(string $key): bool
+    public function has($key)
     {
+        $key = (string) $key;
+
         return $this->inner->has($key);
     }
 }

--- a/src/SimpleCacheContainer.php
+++ b/src/SimpleCacheContainer.php
@@ -33,7 +33,7 @@ class SimpleCacheContainer implements
     /**
      * @inheritDoc
      */
-    public function get(string $id)
+    public function get($id)
     {
         $storage = $this->storage;
 
@@ -53,8 +53,9 @@ class SimpleCacheContainer implements
     /**
      * @inheritDoc
      */
-    public function has(string $id): bool
+    public function has($id)
     {
+        $id = (string) $id;
         $storage = $this->storage;
 
         try {

--- a/tests/helpers/ContainerMock.php
+++ b/tests/helpers/ContainerMock.php
@@ -36,7 +36,7 @@ class ContainerMock extends AbstractMockHelper implements ContainerInterface
      *
      * @since [*next-version*]
      */
-    public function get(string $id)
+    public function get($id)
     {
         return $this->mock->get($id);
     }
@@ -46,7 +46,7 @@ class ContainerMock extends AbstractMockHelper implements ContainerInterface
      *
      * @since [*next-version*]
      */
-    public function has(string $id): bool
+    public function has($id)
     {
         return $this->mock->has($id);
     }
@@ -61,7 +61,7 @@ class ContainerMock extends AbstractMockHelper implements ContainerInterface
      *
      * @return static
      */
-    public function expectHasService(string $key, $value)
+    public function expectHasService($key, $value)
     {
         $this->mock->method('get')
                    ->with($key)
@@ -83,7 +83,7 @@ class ContainerMock extends AbstractMockHelper implements ContainerInterface
      *
      * @return static
      */
-    public function expectNotHasService(string $key)
+    public function expectNotHasService($key)
     {
         $this->mock->method('get')
                    ->with($key)


### PR DESCRIPTION
Reverts Dhii/containers#29, because it was merged into 0.2.x instead of 0.3.x. Thus it broke BC without indicating that.